### PR TITLE
Update admin_events.inc.php

### DIFF
--- a/include/admin_events.inc.php
+++ b/include/admin_events.inc.php
@@ -17,7 +17,7 @@ function photosphere_photo_page()
   
   if (isset($_POST['submit']))
   {
-    $row['is_sphere'] = isset($_POST['is_sphere']);
+    $row['is_sphere'] = intval ( isset($_POST['is_sphere']) ) ;
     
     single_update(
       IMAGES_TABLE,


### PR DESCRIPTION
Forcing int value to avoid Warning:  [mysql error 1366] Incorrect integer value: '' for column `piwigo`.`pwg_images`.`is_sphere` at row 1